### PR TITLE
add requester B2B

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,6 +332,7 @@ payments.mobileB2B options
     	- `destinationAccount`: This value contains the account name used by the business to receive money on the provided destinationChannel. `REQUIRED`
     - `currencyCode`: 3-digit ISO format currency code (e.g `KES`, `USD`, `UGX` etc.) `REQUIRED`
     - `amount`: Payment amount. `REQUIRED`
+    - `requester`: PhoneNumber through which KPLC will send tokens when using B2B to buy electricity tokens.
     - `metadata`: Some optional data to associate with transaction.`REQUIRED`
 
 #### Mobile Data

--- a/lib/AfricasTalking/Payments.rb
+++ b/lib/AfricasTalking/Payments.rb
@@ -76,7 +76,10 @@ class Payments
 			'amount'             => options['amount'],
 			'metadata'           => options['metadata']
 		}
-		url      = getMobilePaymentB2BUrl()   
+		url = getMobilePaymentB2BUrl()
+        if options['requester'] != nil
+		  parameters['requester'] = options['requester']
+        end
 		response = sendJSONRequest(url, parameters)
 		if (@response_code == HTTP_CREATED)
 			resultObj = JSON.parse(response, :quirky_mode =>true)

--- a/lib/AfricasTalking/Payments.rb
+++ b/lib/AfricasTalking/Payments.rb
@@ -77,7 +77,7 @@ class Payments
 			'metadata'           => options['metadata']
 		}
 		url = getMobilePaymentB2BUrl()
-        if options['requester'] != nil
+        if options.key?('requester')
 		  parameters['requester'] = options['requester']
         end
 		response = sendJSONRequest(url, parameters)


### PR DESCRIPTION
We recently updated the B2B API to enable clients pay for tokens.

The new B2B API has a new field in the request body called requester which allows insertion of a phone number through which KPLC will send tokens.

```
{
  "username": "username",
  "productName": "productname",
  "provider" : "Mpesa",
  "transferType": "BusinessPaybill",
    "currencyCode": "KES",
       "amount": 100,
       "destinationChannel" : "888880", 
       "destinationAccount": "01450717531", 
       "requester":"2547XX...",
      "metadata": {
        "shopId": "1234",
        "itemId": "abcdef"
      }
}
```
