### PR TITLE
update httparty dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 PATH
   remote: .
   specs:
-    africastalking-ruby (2.1.5.beta.1)
-      httparty (= 0.16.1)
+    africastalking-ruby (2.1.7)
+      httparty (~> 0.16)
 
 GEM
   remote: https://rubygems.org/
@@ -33,7 +33,8 @@ GEM
     crass (1.0.5)
     diff-lcs (1.3)
     erubi (1.9.0)
-    httparty (0.16.1)
+    httparty (0.21.0)
+      mini_mime (>= 1.0.0)
       multi_xml (>= 0.5.2)
     i18n (1.8.1)
       concurrent-ruby (~> 1.0)
@@ -41,6 +42,7 @@ GEM
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     method_source (0.9.2)
+    mini_mime (1.1.2)
     mini_portile2 (2.4.0)
     minitest (5.13.0)
     multi_xml (0.6.0)
@@ -114,7 +116,7 @@ DEPENDENCIES
   pry (~> 0)
   rake (~> 10.0)
   rspec (~> 3.0)
-  rspec-rails (~> 3.7.2)
+  rspec-rails (~> 3.7, >= 3.7.2)
   rubocop (~> 0.54.0)
 
 BUNDLED WITH

--- a/africastalking-ruby.gemspec
+++ b/africastalking-ruby.gemspec
@@ -36,5 +36,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec-rails', '~> 3.7', '>= 3.7.2'
   spec.add_development_dependency "rubocop", "~> 0.54.0"
   spec.add_development_dependency "pry" , "~> 0"
-  spec.add_dependency "httparty", "0.16.1"
+  spec.add_dependency "httparty", "~> 0.16"
 end


### PR DESCRIPTION
pinned httparty version `0.16.1` has a [security advisory](https://github.com/jnunemaker/httparty/security/advisories/GHSA-5pq7-52mg-hr42)